### PR TITLE
Updated torchvision.models.utils to torch.hub in the import statement…

### DIFF
--- a/models/resnet_pacs.py
+++ b/models/resnet_pacs.py
@@ -1,6 +1,6 @@
 import torch
 from torchvision.models.resnet import ResNet, BasicBlock
-from torchvision.models.utils import load_state_dict_from_url
+from torch.hub import load_state_dict_from_url
 
 resnet18_url = 'https://download.pytorch.org/models/resnet18-5c106cde.pth'
 


### PR DESCRIPTION
This pull request resolves the error raised in the issue "ModuleNotFoundError: No module named 'torchvision.models.utils' #1"